### PR TITLE
fix request path of server timestamp

### DIFF
--- a/okx/client.py
+++ b/okx/client.py
@@ -49,7 +49,7 @@ class Client(object):
         return self._request(method, request_path, params)
 
     def _get_timestamp(self):
-        request_path = c.API_URL + c.SERVER_TIMESTAMP_URL
+        request_path = base_api + c.SERVER_TIMESTAMP_URL
         response = self.client.get(request_path)
         if response.status_code == 200:
             return response.json()['ts']

--- a/okx/client.py
+++ b/okx/client.py
@@ -6,6 +6,8 @@ from . import consts as c, utils, exceptions
 
 import time
 
+import traceback
+
 class Client(object):
 
     def __init__(self, api_key = '-1', api_secret_key = '-1', passphrase = '-1', use_server_time=False, flag='1', base_api = 'https://www.okx.com',debug = False):
@@ -49,7 +51,9 @@ class Client(object):
             try:
                 response = self._request(method, request_path, params)
                 break
-            except:
+            except Exception as e:
+                msg = traceback.format_exc()
+                print(msg)
                 retry_times += 1
                 if retry_times > retry_times_max:
                     print('reach max retry times, exit loop.')

--- a/okx/client.py
+++ b/okx/client.py
@@ -56,22 +56,24 @@ class Client(object):
     def _request_until_success(self, method, request_path, params):
         response = ''
         retry_times = 0
-        retry_times_max = 15
         while True:
             try:
                 response = self._request(method, request_path, params)
+                if not str(response.status_code).startswith('2'):
+                    print('response.status_code:', response.status_code)
+                    print('response.json.code:', response.json()['code'])
+                    print('response.json.msg:', response.json()['msg'])
+                    time.sleep(1)
+                    continue
                 break
             except Exception as e:
                 msg = traceback.format_exc()
-                print(msg)
+                print(e)
                 retry_times += 1
-                if retry_times > retry_times_max:
-                    print('reach max retry times, exit loop.')
-                    break
-                print('http request failed, retry in 1 seconds ... retry times:', retry_times)
+                print('http request retry in 1 seconds, retry times:', retry_times)
                 time.sleep(1)
-        if not str(response.status_code).startswith('2'):
-            raise exceptions.OkxAPIException(response)
+        # if not str(response.status_code).startswith('2'):
+        #     raise exceptions.OkxAPIException(response)
         return response.json()
 
     def _request_without_params(self, method, request_path):
@@ -81,7 +83,7 @@ class Client(object):
         return self._request_until_success(method, request_path, params)
 
     def _get_timestamp(self):
-        request_path = base_api + c.SERVER_TIMESTAMP_URL
+        request_path = self.domain + c.SERVER_TIMESTAMP_URL
         response = self.client.get(request_path)
         if response.status_code == 200:
             return response.json()['ts']


### PR DESCRIPTION
[problem]:
request_path = c.API_URL + c.SERVER_TIMESTAMP_URL
AttributeError: module 'okx.consts' has no attribute 'API_URL'

[solution]:
SERVER_TIMESTAMP_URL = '/api/v5/public/time'
base_api = 'https://www.okx.com/'
thus it can be seen:
request_path = base_api + c.SERVER_TIMESTAMP_URL = 'https://www.okx.com/api/v5/public/time'