### PR TITLE
Initialize websocket in constructor to avoid AttributeError

### DIFF
--- a/okx/websocket/WsPrivateAsync.py
+++ b/okx/websocket/WsPrivateAsync.py
@@ -19,6 +19,7 @@ class WsPrivateAsync:
         self.passphrase = passphrase
         self.secretKey = secretKey
         self.useServerTime = useServerTime
+        self.websocket = None
 
     async def connect(self):
         self.websocket = await self.factory.connect()

--- a/okx/websocket/WsPublicAsync.py
+++ b/okx/websocket/WsPublicAsync.py
@@ -14,6 +14,7 @@ class WsPublicAsync:
         self.callback = None
         self.loop = asyncio.get_event_loop()
         self.factory = WebSocketFactory(url)
+        self.websocket = None
 
     async def connect(self):
         self.websocket = await self.factory.connect()


### PR DESCRIPTION
This PR adds `self.websocket = None` to the constructor of the `WsPublicAsync` and `WsPrivateAsync` classes.

#### Motivation:
Prevents potential `AttributeError` if `self.websocket` is accessed before `connect()` is called.

